### PR TITLE
Add importer for Neon

### DIFF
--- a/ImportApps/neon_csv.js
+++ b/ImportApps/neon_csv.js
@@ -22,14 +22,18 @@ function csvToBanana(csvObj) {
    var banana = {};
    banana['Date'] = csvObj['Date'];
    banana['Description'] = `${csvObj['Description']} ${csvObj['Subject']}`;
+
+   var amount = csvObj['Original amount'] ? csvObj['Original amount'] : csvObj['Amount'];
    
-   if (Number(csvObj['Amount']) > 0) {
-     banana['Income'] = Math.abs(csvObj['Amount']);
+   if (Number(amount) > 0) {
+     banana['Income'] = amount;
      banana['Expenses'] = '';
    } else {
      banana['Income'] = '';
-     banana['Expenses'] = Math.abs(csvObj['Amount']);
+     banana['Expenses'] = amount;
    }
+
+   banana['Amount'] = csvObj['Amount'];
    
    banana['AmountCurrency'] = csvObj['Original amount'];
    banana['ExchangeCurrency'] = csvObj['Original currency'] || 'CHF';
@@ -51,7 +55,16 @@ function exec(inText) {
    var arrayOfObjects = Banana.Converter.arrayToObject(headers, csvFile, true);
    var bananaObjects = arrayOfObjects.map(csvToBanana);
 
-   var tsvFile = Banana.Converter.objectArrayToCsv(['Date', 'Description', 'Income', 'Expenses', 'AmountCurrency','ExchangeCurrency','ExchangeRate'], bananaObjects, '\t');
+   var tsvFile = Banana.Converter.objectArrayToCsv([
+    'Date', 
+    'Description', 
+    'Income', 
+    'Expenses',
+    'Amount',
+    'AmountCurrency',
+    'ExchangeCurrency',
+    'ExchangeRate',
+    ], bananaObjects, '\t');
    
    // Return the converted tsv file
    return tsvFile;

--- a/ImportApps/neon_csv.js
+++ b/ImportApps/neon_csv.js
@@ -1,0 +1,59 @@
+// @id = ch.banana.app.import_neon_csv
+// @api = 1.0
+// @pubdate = 2023-08-30
+// @publisher = bobobo1618
+// @description = Import Neon CSV
+// @doctype = *
+// @docproperties =
+// @task = import.transactions
+// @outputformat = transactions.simple
+// @inputdatasource = openfiledialog
+// @inputencoding = utf8
+// @inputfilefilter = Text files (*.txt *.csv);;All files (*.*)
+
+/* CSV file example:
+"Date";"Amount";"Original amount";"Original currency";"Exchange rate";"Description";"Subject";"Category";"Tags";"Wise";"Spaces"
+"2022-12-30";"-5.00";"";"";"";"App";;"shopping";"";"no";"no"
+"2022-03-03";"2000.00";"";"";"";"Other Account";;"income";"";"no";"no"
+"2022-02-26";"-538.28";"-579.33";"USD";"1.07626";"American Stuff";;"shopping";"";"no";"no"
+*/
+
+function csvToBanana(csvObj) {
+   var banana = {};
+   banana['Date'] = csvObj['Date'];
+   banana['Description'] = `${csvObj['Description']} ${csvObj['Subject']}`;
+   
+   if (Number(csvObj['Amount']) > 0) {
+     banana['Income'] = Math.abs(csvObj['Amount']);
+     banana['Expenses'] = '';
+   } else {
+     banana['Income'] = '';
+     banana['Expenses'] = Math.abs(csvObj['Amount']);
+   }
+   
+   banana['AmountCurrency'] = csvObj['Original amount'];
+   banana['ExchangeCurrency'] = csvObj['Original currency'] || 'CHF';
+   banana['ExchangeRate'] = csvObj['Exchange rate'];
+
+   return banana;
+}
+
+// Parse the data and return the data to be imported as a tab separated file.
+function exec(inText) {
+
+   // Convert a csv file to an array of array.
+   // Parameters are: text to convert, values separator, delimiter for text values
+   var csvFile = Banana.Converter.csvToArray(inText, ';', '"');
+   var headers = csvFile[0];
+   csvFile.splice(0, 1);
+   Banana.console.log(`Found headers: ${headers}`);
+
+   var arrayOfObjects = Banana.Converter.arrayToObject(headers, csvFile, true);
+   var bananaObjects = arrayOfObjects.map(csvToBanana);
+
+   var tsvFile = Banana.Converter.objectArrayToCsv(['Date', 'Description', 'Income', 'Expenses', 'AmountCurrency','ExchangeCurrency','ExchangeRate'], bananaObjects, '\t');
+   
+   // Return the converted tsv file
+   return tsvFile;
+
+}


### PR DESCRIPTION
I wrote this up for CSV files from https://www.neon-free.ch/

Unfortunately the handling of foreign currencies is broken and I'm not sure how they're intended to work. I thought it was intuitive to set Income/Expenses for CHF and AmountCurrency, ExchangeCurrency and ExchangeRate for foreign currencies but Banana does something totally unexpected when given these inputs: it ignores the amount set in Income/Expenses and replaces it with AmountCurrency.

I guess I should go lower level and use AccountCredit and AccountDebit to configure the direction of the transfer but it isn't clear how to get the actual account names.

So I don't expect this to work straight away but please let me know how you'd prefer this to be handled.