### PR TITLE
comment: credit card format2 is used for business and private accounts

### DIFF
--- a/ImportApps/pf_import_bank_statement_csv/ch.banana.switzerland.import.postfinance.js
+++ b/ImportApps/pf_import_bank_statement_csv/ch.banana.switzerland.import.postfinance.js
@@ -451,6 +451,8 @@ function PFCSVFormat6() {
 
 
 /**
+ * This format is used for both Business and Private accounts.
+ * 
  * Kartenkonto:;0000 0000 0000 0000;;;;
  * Karte:;XXXX XXXX XXXX 1111 PostFinance Visa Business Card;;;;
  * Karteninhaber:;BRUNO FREY;;;;


### PR DESCRIPTION
Added a comment to specify that the Credit Card format2 works for both private and business accounts